### PR TITLE
時間選択ポップアップの変更

### DIFF
--- a/src/components/room/SetBathGoal.js
+++ b/src/components/room/SetBathGoal.js
@@ -99,7 +99,7 @@ const SetBathGoal = ({
       <div className="flex-box">
         <div className="text-wrapper">
           <FontAwesomeIcon icon={faBath} />
-          <h3>おふろの日時</h3>
+          <h3>おふろの時間</h3>
         </div>
         <input
           ref={inputRef}


### PR DESCRIPTION
## 関連 issue

- #62 

## 説明

- 初期値を現在から10分後に設定
- 日付選択をなくし、現在の1分後から24時間後までの時間のみ選べるように変更(現在時刻は明日の現在時刻になります)

## 動作確認手順
デプロイにも反映したので、スマホでも確認OK

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
