### PR TITLE
報酬画面の記述の修正

### DIFF
--- a/src/components/css/room/LevelUp.css
+++ b/src/components/css/room/LevelUp.css
@@ -100,7 +100,14 @@
 .level-up-container > .level-up .reward-wrapper p {
   font-size: 14px;
   font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.level-up-container > .level-up .reward-wrapper .description-wrapper {
+  font-size: 14px;
+  font-weight: 700;
   margin-bottom: 32px;
+  color: var(--sub-500);
 }
 
 .level-up-container > .flex-box .cat {

--- a/src/components/css/room/LevelUp.css
+++ b/src/components/css/room/LevelUp.css
@@ -103,13 +103,6 @@
   margin-bottom: 16px;
 }
 
-.level-up-container > .level-up .reward-wrapper .description-wrapper {
-  font-size: 14px;
-  font-weight: 700;
-  margin-bottom: 32px;
-  color: var(--sub-500);
-}
-
 .level-up-container > .flex-box .cat {
   position: fixed;
   bottom: -120px;

--- a/src/components/css/room/LevelUp.css
+++ b/src/components/css/room/LevelUp.css
@@ -78,13 +78,14 @@
   flex-direction: column;
   align-items: center;
   position: relative;
+  margin-bottom: 16px;
 }
 
 .level-up-container > .level-up .reward-wrapper img {
   width: 120px;
   height: auto;
   box-shadow: 0px 4px 0px rgba(0, 0, 0, 0.2);
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .level-up-container > .level-up .reward-wrapper .stamp,
@@ -100,7 +101,7 @@
 .level-up-container > .level-up .reward-wrapper p {
   font-size: 14px;
   font-weight: 700;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .level-up-container > .flex-box .cat {

--- a/src/components/room/LevelUp.js
+++ b/src/components/room/LevelUp.js
@@ -84,7 +84,7 @@ const LevelUp = ({ nextPoint, point, closeLevelUp }) => {
               <p>
                 {(rewardData.type === "themeColor" ||
                   rewardData.type === "icon") &&
-                  "せっていから変更できます"}
+                  "※せっていから変更できます"}
               </p>
             </div>
           ) : (

--- a/src/components/room/LevelUp.js
+++ b/src/components/room/LevelUp.js
@@ -75,7 +75,17 @@ const LevelUp = ({ nextPoint, point, closeLevelUp }) => {
                 src={rewardData.path}
                 alt="ほうしゅう"
               />
-              <p>報酬をかくとくしました</p>
+              <p>
+                {rewardData.type === "stamp" && "スタンプをかくとくしました"}
+                {rewardData.type === "themeColor" &&
+                  "テーマカラーをかくとくしました"}
+                {rewardData.type === "icon" && "アイコンをかくとくしました"}
+              </p>
+              <p className="description-wrapper">
+                {(rewardData.type === "themeColor" ||
+                  rewardData.type === "icon") &&
+                  "せっていから変更できます"}
+              </p>
             </div>
           ) : (
             <div className="point-wrapper">

--- a/src/components/room/LevelUp.js
+++ b/src/components/room/LevelUp.js
@@ -81,7 +81,7 @@ const LevelUp = ({ nextPoint, point, closeLevelUp }) => {
                   "テーマカラーをかくとくしました"}
                 {rewardData.type === "icon" && "アイコンをかくとくしました"}
               </p>
-              <p className="description-wrapper">
+              <p>
                 {(rewardData.type === "themeColor" ||
                   rewardData.type === "icon") &&
                   "せっていから変更できます"}


### PR DESCRIPTION
## 関連 issue

- #63 

## 説明

- 報酬の種類ごとに「スタンプをかくとくしました」「アイコンをかくとくしました」「テーマカラーをかくとくしました」と記述を変更
- アイコン、テーマカラー獲得時に「せっていから変更できます」の記述を追加

## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

- [x] 報酬の種類ごとに記述が正しいものになっていること

## 参考 URL 等
